### PR TITLE
Theme & language presistence via express-session -junglemoon

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,6 +1,7 @@
 var express = require("express");
 var path = require("path");
 var logger = require("morgan");
+var session = require("express-session");
 
 var indexRouter = require("./routes/index");
 
@@ -11,6 +12,7 @@ app.use(logger("dev"));
 app.use(express.json());
 app.use(express.urlencoded({ extended: true }));
 app.use(express.static(path.join(__dirname, "public")));
+app.use(session({secret: 'jin.ri.tv'}));
 
 // view engine setup
 app.set("views", path.join(__dirname, "views"));

--- a/public/javascripts/custom-theme.js
+++ b/public/javascripts/custom-theme.js
@@ -3,7 +3,7 @@ const THEMES = {
     Dark: "dark-mode",
     Light: "light-mode",
   };
-  var CurrentTheme = THEMES.Light;
+  var CurrentTheme = $("body").hasClass(THEMES.Light) ? THEMES.Light : THEMES.Dark;
 
   // change the class of the wrapper to change the theme colors
 var $ThemeWrapper, $themeLabel, $themeIcon;
@@ -25,4 +25,7 @@ function toggleDarkMode() {
     $themeIcon.text(nextTheme == THEMES.Dark ? "🌞" : "🌚");
     $themeLabel.text(getText(`${CurrentTheme}-label`));
     CurrentTheme = nextTheme;
+    $.get('/setTheme/' + CurrentTheme, function (json) {
+		let nothing = "";
+    });
   }

--- a/public/javascripts/index.js
+++ b/public/javascripts/index.js
@@ -94,6 +94,9 @@ function getPageHTML() {
 function updateLanguage(language) {
   console.log("updating ", language);
   setLanguage(language);
+  $.get('/setLang/' + language, function (json) {
+                let nothing = "";
+    });
   // first check if the desired language is already loaded (empty if not loaded)
   let loadedLang = getThisLanguageText();
   console.log(loadedLang)

--- a/public/javascripts/text-handling.js
+++ b/public/javascripts/text-handling.js
@@ -20,6 +20,7 @@ function setLanguage(language) {
   }
   
   function getLanguage() {
+    if ($("#sLang").html() != "") { _CURRENT_LANGUAGE = $("#Lang").html(); }
     return _CURRENT_LANGUAGE_;
   }
 

--- a/routes/index.js
+++ b/routes/index.js
@@ -7,14 +7,29 @@ const {LoadLanguageJSON, getText} = require("../backend/localizations/localizati
 
 const {Quiz} = require("../backend/quiz_questions");
 
-// Home/Main quiz page
-router.get("/", (req, res) => {
-  res.render("index");
+router.get("/setTheme/:theme", (req, res) => {
+	req.session.theme = req.params.theme;
+	req.session.save();
+});
+router.get("/setLang/:lang", (req, res) => {
+	req.session.language = req.params.lang;
+	req.session.save();
 });
 
+// Home/Main quiz page
+router.get("/", (req, res) => {
+	if (!req.session.theme)
+	{
+		req.session.theme = "light-mode";
+	}
+    let THEME_TO_SHOW = req.session.theme;
+    res.render("index", {
+	Theme: THEME_TO_SHOW,
+    });
+});
 // renders the html for the quiz and most of the page
 router.post('/getHtml', function(req, res){
-  let LANGUAGE_TO_GET = req.body.language;
+  let LANGUAGE_TO_GET = req.session.language && req.session.language != "" ? req.session.language : req.body.language;
   console.log(`rendering html for ${LANGUAGE_TO_GET}`);
   const onLangLoaded = (result, error)=>{ 
     res.render("./full_page", {

--- a/views/index.ejs
+++ b/views/index.ejs
@@ -7,8 +7,7 @@
     <meta name="author" content="">
     <%- include ("./partials/stylesheets") %>
   </head>
-  <body id="full-page" class="light-mode">
-  
+  <body id="full-page" class="<%= Theme %>">
   </body>
   <%- include ("./partials/scripts") %>
 

--- a/views/not_found.ejs
+++ b/views/not_found.ejs
@@ -7,7 +7,7 @@
     <meta name="author" content="">
     <%- include ("./partials/stylesheets") %>
   </head>
-  <body id="full-page" class="light-mode">
+  <body id="full-page" class="<% Theme %>">
     <main role="main" class="container d-flex justify-content-center">
       <div class="welcome-container">
         <p style="font-size: 100px; font-weight: bold;">404</p>


### PR DESCRIPTION
With NPM package [Express-session](https://www.npmjs.com/package/express-session), language and light/dark-mode theme persistence added, as per bug/feature request: "- By clicking twiri in the top left to go back to main page, it turns off dark mode."