### PR TITLE
Ysf/bfix calc

### DIFF
--- a/backend/calculate_streamer.js
+++ b/backend/calculate_streamer.js
@@ -219,7 +219,7 @@ function matchStreamers(prefs, streamers) {
     };
 
     // check against average viewers preference
-    if (streamer) {
+    if (streamer.avg_viewers) {
       let viewerRange = getMinMaxViewers(prefs.average_viewers);
       let score = countNearScore(
         ATTRIBUTE_POINTS.average_viewers,
@@ -238,7 +238,8 @@ function matchStreamers(prefs, streamers) {
     // get the streamers and the user's language arrays
     let totalLangMatch = 0;
     preferredLanguages.forEach((strLang) => {
-      if (streamer.languages.includes(strLang)) {
+      // Database has uppercased language name code: EN, KR, CN etc
+      if (streamer.languages.includes(strLang.toUpperCase())) {
         totalLangMatch += 1;
       }
     });
@@ -390,8 +391,15 @@ function getMinMaxViewers(average_viewers) {
   if (!average_viewers) {
     return [2500, 7500];
   }
-  const minAvgViewer = Number(average_viewers.min || 2500);
-  const maxAvgViewer = Number(average_viewers.max || 7500);
+
+  let minAvgViewer = Number(average_viewers.min || 2500);
+  let maxAvgViewer = Number(average_viewers.max || 7500);
+
+  // frontend doesnt' send over 2000 for max value (it said 2000+ on the UI)
+  // so we modify max value if user submit 2000+ to also include large streamers
+  if (maxAvgViewer == 2000) {
+    maxAvgViewer = 10000
+  }
   return [minAvgViewer, maxAvgViewer];
 }
 
@@ -434,12 +442,12 @@ function getFollowerCountRange(follower_count) {
   return [0, 1000000]; // Returns all if not selected
 }
 
-
 function getLanguageNames(languages) {
   // Frontend has long language name, DB has short language names.
   if (!languages) {
     return [];
   }
+
   const nameMap = {
     thai: "th",
     japanese: "jp",

--- a/backend/db/csv_db.js
+++ b/backend/db/csv_db.js
@@ -17,7 +17,8 @@ function parseLanguages(languagesString) {
   for(const item of split) {
     const trimmed = item.trim();
     if(trimmed !== "") {
-      languages.push(trimmed);
+      // to upper case is needed to guard against inconsistent data, EN, En , en
+      languages.push(trimmed.toUpperCase());
     }
   }
   return languages;
@@ -41,10 +42,30 @@ function parseChatVibes(chatVibesString) {
   for(const item of split) {
     const trimmed = item.trim();
     if(trimmed !== "") {
-      chatVibes.push(trimmed);
+      // to lower case is needed to make sure no case difference cause issue in matching
+      // Ex: Funny (in DB) vs funny (in input)
+      chatVibes.push(trimmed.toLowerCase());
     }
   }
   return chatVibes;
+}
+
+function parseGender(rawGender) {
+  const trimmed = rawGender.trim();
+  if (trimmed.toUpperCase() == "F") {
+    return "F";
+  } else if (trimmed.toUpperCase() == "M") {
+    return "M";
+  }
+  return "";
+}
+
+function parseAvgViewer(rawAvgViewer) {
+  let i = parseInt(rawAvgViewer.replace(',', ''));
+  if (Number.isNaN(i)) {
+    return null;
+  }
+  return i;
 }
 
 // Gets string content of CSV file, parses it into array of {[dbcolumn]:value}
@@ -79,9 +100,9 @@ function parseCsvDataToJson(csvFileData) {
       user_name: dataRow[1].toLowerCase(),
       nickname: dataRow[2],
       logo: null,
-      mature_stream: dataRow[7] === "TRUE",
-      gender: dataRow[11],
-      avg_viewers: dataRow[14],
+      mature_stream: dataRow[7].toUpperCase() === "TRUE",
+      gender: parseGender(dataRow[11]),
+      avg_viewers: parseAvgViewer(dataRow[14]),
       languages: parseLanguages(dataRow[3]),
       categories: parseCategories(dataRow[12]),
       chat_vibes: parseChatVibes(dataRow[4])


### PR DESCRIPTION
[bfix-calc] Fix calculation & data collection
Calculation
- Fix language score always zero because case issue.
- Handle over 2000+ average watchers input

Sanitize data collection:
- Average viewer: number only
- Gender: f / m only
- Chatvibes: lower cased items
- Languages: Uppercased items.

[bfix-calc] Fix score ranking
Using local variable instead of global to prevent race condition issue
when the variable is modified by different request at the same time