### PR TITLE
Fix bug where theme switcher is not showing correct text

### DIFF
--- a/public/javascripts/about.js
+++ b/public/javascripts/about.js
@@ -1,6 +1,5 @@
 $(document).ready(function () {
   setLanguage(getDefaultLanguage());
-  assignThemes();
   getDataForTheme();
 });
 
@@ -17,6 +16,7 @@ function getDataForTheme() {
       } else {
         // data is loaded so now start the page effects
         setLanguageTexts(data);
+        assignThemes();
       }
     },
   });

--- a/public/javascripts/contribution.js
+++ b/public/javascripts/contribution.js
@@ -19,7 +19,6 @@ const carouselSlideList = [
 $(document).ready(function () {
   setCarouselSlide(0);
   setLanguage(getDefaultLanguage());
-  assignThemes();
   getDataForTheme();
 });
 
@@ -36,6 +35,7 @@ function getDataForTheme() {
       } else {
         // data is loaded so now start the page effects
         setLanguageTexts(data);
+        assignThemes();
       }
     },
   });

--- a/public/javascripts/custom-theme.js
+++ b/public/javascripts/custom-theme.js
@@ -1,31 +1,41 @@
 // The theme, either 'light' or 'dark'
 const THEMES = {
-    Dark: "dark-mode",
-    Light: "light-mode",
-  };
-  var CurrentTheme = $("body").hasClass(THEMES.Light) ? THEMES.Light : THEMES.Dark;
+  Dark: "dark-mode",
+  Light: "light-mode",
+};
+var CurrentTheme = $("body").hasClass(THEMES.Light)
+  ? THEMES.Light
+  : THEMES.Dark;
 
-  // change the class of the wrapper to change the theme colors
+// change the class of the wrapper to change the theme colors
 var $ThemeWrapper, $themeLabel, $themeIcon;
 
-
 function assignThemes() {
-    $ThemeWrapper = $("#full-page");
-    $themeIcon = $("#theme-icon");
-    $themeLabel = $("#theme-label");
-  }
+  $ThemeWrapper = $("#full-page");
+  $themeIcon = $("#theme-icon");
+  $themeLabel = $("#theme-label");
+
+  // On page load set the theme selector to switch to the next theme based on what default theme is configured.
+  loadTheme();
+}
+
+function loadTheme() {
+  let nextTheme = CurrentTheme == THEMES.Dark ? THEMES.Light : THEMES.Dark;
+  $themeIcon.text(CurrentTheme == THEMES.Dark ? "🌞" : "🌚");
+  $themeLabel.text(getText(`${nextTheme}-label`));
+}
 
 // Toggles the theme to dark/light mode
 function toggleDarkMode() {
-    // remove current theme
-    $ThemeWrapper.removeClass(CurrentTheme);
-    // get opposite of current theme for the next theme
-    let nextTheme = CurrentTheme == THEMES.Dark ? THEMES.Light : THEMES.Dark;
-    $ThemeWrapper.addClass(nextTheme);
-    $themeIcon.text(nextTheme == THEMES.Dark ? "🌞" : "🌚");
-    $themeLabel.text(getText(`${CurrentTheme}-label`));
-    CurrentTheme = nextTheme;
-    $.get('/setTheme/' + CurrentTheme, function (json) {
-		let nothing = "";
-    });
-  }
+  // remove current theme
+  $ThemeWrapper.removeClass(CurrentTheme);
+  // get opposite of current theme for the next theme
+  let nextTheme = CurrentTheme == THEMES.Dark ? THEMES.Light : THEMES.Dark;
+  $ThemeWrapper.addClass(nextTheme);
+  $themeIcon.text(nextTheme == THEMES.Dark ? "🌞" : "🌚");
+  $themeLabel.text(getText(`${CurrentTheme}-label`));
+  CurrentTheme = nextTheme;
+  $.get("/setTheme/" + CurrentTheme, function (json) {
+    let nothing = "";
+  });
+}

--- a/public/javascripts/submission.js
+++ b/public/javascripts/submission.js
@@ -1,6 +1,5 @@
 $(document).ready(function () {
   setLanguage(getDefaultLanguage());
-  assignThemes();
   getDataForTheme();
 });
 
@@ -17,6 +16,7 @@ function getDataForTheme() {
       } else {
         // data is loaded so now start the page effects
         setLanguageTexts(data);
+        assignThemes();
       }
     },
   });

--- a/routes/index.js
+++ b/routes/index.js
@@ -15,11 +15,13 @@ const _DEFAULT_THEME_ = "dark-mode";
 router.get("/setTheme/:theme", (req, res) => {
   req.session.theme = req.params.theme;
   req.session.save();
+  res.status(200).send("OK");
 });
 
 router.get("/setLang/:lang", (req, res) => {
   req.session.language = req.params.lang;
   req.session.save();
+  res.status(200).send("OK");
 });
 
 // Home/Main quiz page

--- a/views/about.ejs
+++ b/views/about.ejs
@@ -209,7 +209,6 @@
       About:  getText('footer-about'),
       Submit:  getText('footer-submit'),
       Contribute:  getText('footer-contribute'),
-      DarkMode:  getText('dark-mode-label')
   }) %>
 
 </body>

--- a/views/contribution.ejs
+++ b/views/contribution.ejs
@@ -260,7 +260,6 @@
       About:  getText('footer-about'),
       Submit:  getText('footer-submit'),
       Contribute:  getText('footer-contribute'),
-      DarkMode:  getText('dark-mode-label')
   }) %>
 </body>
 

--- a/views/full_page.ejs
+++ b/views/full_page.ejs
@@ -42,7 +42,6 @@
     About:  getText('footer-about'),
     Submit:  getText('footer-submit'),
     Contribute:  getText('footer-contribute'),
-    DarkMode:  getText('dark-mode-label')
 }) %>
 
 <%- include ("./partials/quiz_modal",{ getText, Quiz }) %>

--- a/views/partials/footer.ejs
+++ b/views/partials/footer.ejs
@@ -10,8 +10,8 @@
       
         <div class="footer-text col-6 col-lg-3 text-center text-lg-right"><%= CopyrightText %></div>
         <div onclick="toggleDarkMode()" id="dark-mode-toggle" class="col-6 col-lg-2 mr-lg-2 text-center text-lg-right">
-          <span id="theme-icon">🌚</span>
-          <span id="theme-label"><%= DarkMode %></span>
+          <span id="theme-icon"></span>
+          <span id="theme-label"></span>
         </div>
       </div>
     </div>

--- a/views/submission.ejs
+++ b/views/submission.ejs
@@ -122,7 +122,6 @@
       About:  getText('footer-about'),
       Submit:  getText('footer-submit'),
       Contribute:  getText('footer-contribute'),
-      DarkMode:  getText('dark-mode-label')
   }) %>
 
 </body>


### PR DESCRIPTION
For example if I load the page and the current mode is "dark", the switcher asks me if I want to switch to dark (but like I'm already on dark mode). 

Reworked code to initialize the switcher in javascript based on current mode configured and reduce the logic in the template.

Also fixed a small issue where the endpoint for "saving the theme" would never close out the request.

