### PR TITLE
Fix bug where language switcher gets stuck or does not update page fully

### DIFF
--- a/public/javascripts/about.js
+++ b/public/javascripts/about.js
@@ -40,5 +40,5 @@ function updateLanguage(language) {
     console.log("Language already loaded.");
     return;
   }
-  getDataForTheme();
+  window.location.reload();
 }

--- a/public/javascripts/contribution.js
+++ b/public/javascripts/contribution.js
@@ -59,7 +59,7 @@ function updateLanguage(language) {
     console.log("Language already loaded.");
     return;
   }
-  getDataForTheme();
+  window.location.reload();
 }
 
 $("#carouselIndicators").on("slide.bs.carousel", function (event) {

--- a/public/javascripts/submission.js
+++ b/public/javascripts/submission.js
@@ -40,7 +40,7 @@ function updateLanguage(language) {
     console.log("Language already loaded.");
     return;
   }
-  getDataForTheme();
+  window.location.reload();
 }
 
 function submitFormEvent(e) {

--- a/routes/index.js
+++ b/routes/index.js
@@ -55,7 +55,10 @@ router.post("/getHtml", function (req, res) {
 
 // renders the html for the quiz and most of the page
 router.post("/getQuizData", function (req, res) {
-  let LANGUAGE_TO_GET = req.body.language;
+  let LANGUAGE_TO_GET =
+    req.session.language && req.session.language != ""
+      ? req.session.language
+      : req.body.language;
   console.log(`getting rest of data for ${LANGUAGE_TO_GET}`);
   const onLangLoaded = (result, error) => {
     let requiredTexts = {


### PR DESCRIPTION
For the about, contribute, and submit pages I just resorted to reloading the page. We need to refetch the template rendered HTML when the language has changed (otherwise only the texts set by JS are updated).

How to reproduce bug:

- Switch to another language
- Reload page
- Now try to switch back to your native language

Expected: it should change the language back
Actual: the language does not update

Also if you set a language that isn't your browser's default and then load the page again, it will only partially
translate the page to the selected language.